### PR TITLE
type: correct the labels to be a const variable

### DIFF
--- a/src/windows-1252.d.ts
+++ b/src/windows-1252.d.ts
@@ -14,5 +14,5 @@ declare module 'windows-1252' {
     buffer: Uint16Array | Uint8Array | Buffer | string,
     options?: DecodeOptions
   ): string;
-  export type labels = string[];
+  export const labels: string[];
 }


### PR DESCRIPTION
This fixes `labels` to be used as an `string[]` variable instead of a type alias :)